### PR TITLE
Bugfix: flux-capacitor-boot promise resolving

### DIFF
--- a/packages/flux-capacitor-boot/CHANGELOG.md
+++ b/packages/flux-capacitor-boot/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog - flux-capacitor-boot
+
+## 0.2.1
+
+- Fix crash if a promise is passed to `use.app()` or `use.store()`
+
+## 0.2.0
+
+Initial release.

--- a/packages/flux-capacitor-boot/package.json
+++ b/packages/flux-capacitor-boot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flux-capacitor-boot",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "scripts": {
     "build": "babel src/ --out-dir lib/ --ignore __tests__ --source-maps",
     "test": "standard && ava",

--- a/packages/flux-capacitor-boot/src/__tests__/integration.test.js
+++ b/packages/flux-capacitor-boot/src/__tests__/integration.test.js
@@ -102,7 +102,7 @@ test(`reading a single event works`, async (t) => {
 test(`websocket propagates dispatched events`, async (t) => {
   t.plan(3)
 
-  const store = mockStore()
+  const store = await mockStore()
   const authorizer = sinon.spy(
     (event) => event.type === 'restrictedEvent' ? authorize.deny() : authorize.allow()
   )
@@ -168,7 +168,8 @@ function mockStore () {
   sinon.spy(store, 'dispatch')
   sinon.spy(store, 'subscribe')
 
-  return store
+  // Using a Promise just to make sure the bootstrapping works with async instantiation
+  return Promise.resolve(store)
 }
 
 function mockDatabase () {

--- a/packages/flux-capacitor-boot/src/express/createStore.js
+++ b/packages/flux-capacitor-boot/src/express/createStore.js
@@ -5,11 +5,10 @@ module.exports = createStore
 /**
  * @param {Function} rootReducer    (Database, Event) => Changeset
  * @param {Database|Promise<Database>} databaseOrPromise  Result of `connectTo()` or `await connectTo()`
- * @return {Promise<Function>}
+ * @return {Promise<Store>}
  */
 function createStore (rootReducer, databaseOrPromise) {
-  return () => Promise.resolve(databaseOrPromise).then((database) => {
-    const store = fluxCapacitor.createStore(rootReducer, databaseOrPromise)
-    return { store }
+  return Promise.resolve(databaseOrPromise).then((database) => {
+    return fluxCapacitor.createStore(rootReducer, database)
   })
 }

--- a/packages/flux-capacitor-boot/src/express/use.js
+++ b/packages/flux-capacitor-boot/src/express/use.js
@@ -3,10 +3,23 @@ const authorize = require('../authorize')
 const useAsyncHandler = require('./util/useAsyncHandler')
 
 module.exports = {
-  app (app) {
-    return () => ({ app })
+  /**
+   * Make the bootstrapper use this express server app.
+   *
+   * @param {Express.App|Promise<Express.App>}
+   * @return {Function}
+   */
+  app (appOrPromise) {
+    return () => Promise.resolve(appOrPromise)
+      .then((app) => ({ app }))
   },
 
+  /**
+   * Make the app use this express middlewares.
+   *
+   * @param {Function|Function[]} middlewares
+   * @return {Function}
+   */
   expressMiddleware (middlewares) {
     middlewares = Array.isArray(middlewares) ? middlewares : [ middlewares ]
 
@@ -17,9 +30,12 @@ module.exports = {
   },
 
   /**
+   * Set up this RESTful route.
+   *
    * @param {string} path
    * @param {Function} handler      (Express.Route) => void
    * @param {Function} [preHandler] For authorization and such. (Request, Response) => Promise|void
+   * @return {Function}
    */
   route (path, handler, preHandler = allowAll) {
     return (bootstrapped) => {
@@ -31,8 +47,15 @@ module.exports = {
     }
   },
 
-  store (store) {
-    return () => ({ store })
+  /**
+   * Make the bootstrapper use this flux capacitor store.
+   *
+   * @param {Store|Promise<Store>}
+   * @return {Function}
+   */
+  store (storeOrPromise) {
+    return () => Promise.resolve(storeOrPromise)
+      .then((store) => ({ store }))
   }
 }
 


### PR DESCRIPTION
Fixes a crash that occured when passing a promise to `use.app()` or `use.store()`